### PR TITLE
ci: release 1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@doist/react-interpolate",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@doist/react-interpolate",
-            "version": "1.0.0",
+            "version": "1.1.0",
             "license": "MIT",
             "devDependencies": {
                 "@babel/cli": "7.18.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@doist/react-interpolate",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "license": "MIT",
     "description": "A string interpolation component that formats and interpolates a template string in a safe way",
     "main": "dist/react-interpolate.cjs",


### PR DESCRIPTION
- [chore: add node v21 support and remove support for v18 and npm v9 ([#33](https://github.com/Doist/react-interpolate/pull/33))