### PR TITLE
ci: Enable trusted publishing and npm provenance

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,12 @@ on:
         types: [created]
     workflow_dispatch:
 
+permissions:
+    # Enable the use of OIDC for trusted publishing and npm provenance
+    id-token: write
+    # Enable the use of GitHub Packages registry
+    packages: write
+
 jobs:
     publish:
         runs-on: ubuntu-latest
@@ -22,6 +28,9 @@ jobs:
               uses: actions/setup-node@v3
               with:
                   node-version: ${{ steps.nvmrc.outputs.NODE_VERSION }}
+
+            - name: Ensure npm 11.5.1 or later is installed
+              run: npm install -g npm@latest
 
             - name: Install dependencies
               run: npm ci --legacy-peer-deps
@@ -42,7 +51,10 @@ jobs:
                   scope: '@doist'
             - run: npm publish
               env:
-                  NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+                  NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Clear npm config between GitHub/npm registries
+              run: rm -f $NPM_CONFIG_USERCONFIG
 
             - name: Publish to npm registry
               uses: actions/setup-node@v3
@@ -50,6 +62,4 @@ jobs:
                   node-version: ${{ steps.nvmrc.outputs.NODE_VERSION }}
                   registry-url: https://registry.npmjs.org/
                   scope: '@doist'
-            - run: npm publish
-              env:
-                  NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+            - run: npm publish --provenance --access public

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
     "name": "@doist/react-interpolate",
     "version": "2.2.1",
+    "repository": "https://github.com/Doist/react-interpolate",
     "license": "MIT",
     "description": "A string interpolation component that formats and interpolates a template string in a safe way",
     "main": "dist/react-interpolate.cjs",
@@ -23,10 +24,6 @@
         "prettify": "prettier --write ."
     },
     "prettier": "@doist/prettier-config",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/Doist/react-interpolate.git"
-    },
     "keywords": [
         "react",
         "interpolate",


### PR DESCRIPTION
## Overview

This PR updates the repository’s GitHub Actions workflow to use **npm’s Trusted Publishing** feature for package releases. Using Trusted Publishing eliminates the need to store long-lived npm tokens in GitHub secrets, reducing security risks and simplifying credential management. This also standardizes the publishing process across repositories.

> [!IMPORTANT]
> The npm organization and repository must be linked and authorized for Trusted Publishing before merging.

**What’s changing:**

* Replaces manual `NPM_TOKEN` authentication with GitHub’s **OpenID Connect (OIDC)**–based authentication.
* Updates the release workflow configuration to align with [npm’s Trusted Publishers documentation](https://docs.npmjs.com/trusted-publishers)
* Ensures that package publishing permissions are managed directly through GitHub and npm, improving security and maintainability.