### PR TITLE
chore: Bump version to 2.2.2 in package.json and package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@doist/react-interpolate",
-    "version": "2.2.1",
+    "version": "2.2.2",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@doist/react-interpolate",
-            "version": "2.2.1",
+            "version": "2.2.2",
             "license": "MIT",
             "devDependencies": {
                 "@babel/cli": "7.18.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@doist/react-interpolate",
-    "version": "2.2.1",
+    "version": "2.2.2",
     "repository": "https://github.com/Doist/react-interpolate",
     "license": "MIT",
     "description": "A string interpolation component that formats and interpolates a template string in a safe way",


### PR DESCRIPTION
## Overview

Follow-up to https://github.com/Doist/react-interpolate/pull/52 to bump the version to the next one. This should've been in that linked PR, but for some reason my changes weren't committed/stashed and the publishing workflow [failed](https://github.com/Doist/react-interpolate/actions/runs/18750426308/job/53488255254).